### PR TITLE
Add support for multiple packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Go-ERD [WIP]
 
-Entity Relationship Diagrams for Golang with GraphViz.
+Entity Relationship Diagrams for Golang with GraphViz. This fork of the Go-ERD package supports multiple packages (though that support is somewhat buggy).
 
 # Why
 
@@ -9,15 +9,15 @@ Visualize package's types and their inter-relationships to aid exploring and stu
 # Installation
 
 ```
-go get github.com/gmarik/go-erd
+go get github.com/lelandbatey/go-erd
 ```
 
 # Use
 
 ```
-# go-erd -path <path>
+# go-erd -path <path> [-path <path>]...
 # ie
-go-erd -path $(go env GOROOT)/src/go/ast/ |dot -Tsvg > out.svg
+go-erd -path $(go env GOROOT)/src/image -path $(go env GOROOT)/src/image/color |dot -Tsvg > /tmp/out.svg
 open out.svg
 ```
 
@@ -34,9 +34,3 @@ open out.svg
 Simple on the outside very complex on the inside.
 
 ![go/ast](https://cdn.rawgit.com/gmarik/go-erd/master/examples/net-http.svg)
-
-## TODO
-
-- [ ] cleanup
-- [ ] exhaustive coverage for types
-- [ ] flag to show only exported fields


### PR DESCRIPTION
This PR adds support for creating an ERD out of multiple interrelated packages, instead of being limited to just one package. This is very useful for seeing the relationships across packages and repositories.

Example for how to use this CLI tool with multiple paths:

```
go-erd -path $(go env GOROOT)/src/image -path $(go env GOROOT)/src/image/color |dot -Tsvg > /tmp/out.svg
eog /tmp/out.svg
```
![Example output](https://user-images.githubusercontent.com/1964720/72389307-e9b6d580-36dc-11ea-81c9-2539c95456f3.png)